### PR TITLE
feat: GitHub Actions CI/CD pipelines and Dockerfiles

### DIFF
--- a/.github/workflows/cd-admin-service.yml
+++ b/.github/workflows/cd-admin-service.yml
@@ -1,0 +1,71 @@
+name: CD - AdminService
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/AdminService/**'
+      - 'src/Volentry.Core/**'
+      - 'src/Volentry.Infrastructure/**'
+      - '.github/workflows/cd-admin-service.yml'
+
+env:
+  DOTNET_VERSION: '8.0.x'
+  REGISTRY: ${{ secrets.AZURE_CONTAINER_REGISTRY }}.azurecr.io
+  IMAGE_NAME: admin-service
+
+jobs:
+  build-and-push:
+    name: Build & Push Image
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Run tests
+        run: |
+          dotnet test tests/AdminService.Tests --configuration Release --verbosity normal
+          dotnet test tests/Volentry.Core.Tests --configuration Release --verbosity normal
+
+      - name: Log in to Azure Container Registry
+        uses: azure/docker-login@v1
+        with:
+          login-server: ${{ env.REGISTRY }}
+          username: ${{ secrets.ACR_USERNAME }}
+          password: ${{ secrets.ACR_PASSWORD }}
+
+      - name: Build and push Docker image
+        run: |
+          docker build \
+            -f src/AdminService/AdminService.Api/Dockerfile \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+            .
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+
+  deploy:
+    name: Deploy to Container Apps
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    environment: production
+
+    steps:
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Deploy to Container App
+        uses: azure/container-apps-deploy-action@v1
+        with:
+          containerAppName: admin-service
+          resourceGroup: ${{ secrets.AZURE_RESOURCE_GROUP }}
+          imageToDeploy: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}

--- a/.github/workflows/cd-volunteer-service.yml
+++ b/.github/workflows/cd-volunteer-service.yml
@@ -1,0 +1,71 @@
+name: CD - VolunteerService
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/VolunteerService/**'
+      - 'src/Volentry.Core/**'
+      - 'src/Volentry.Infrastructure/**'
+      - '.github/workflows/cd-volunteer-service.yml'
+
+env:
+  DOTNET_VERSION: '8.0.x'
+  REGISTRY: ${{ secrets.AZURE_CONTAINER_REGISTRY }}.azurecr.io
+  IMAGE_NAME: volunteer-service
+
+jobs:
+  build-and-push:
+    name: Build & Push Image
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Run tests
+        run: |
+          dotnet test tests/VolunteerService.Tests --configuration Release --verbosity normal
+          dotnet test tests/Volentry.Core.Tests --configuration Release --verbosity normal
+
+      - name: Log in to Azure Container Registry
+        uses: azure/docker-login@v1
+        with:
+          login-server: ${{ env.REGISTRY }}
+          username: ${{ secrets.ACR_USERNAME }}
+          password: ${{ secrets.ACR_PASSWORD }}
+
+      - name: Build and push Docker image
+        run: |
+          docker build \
+            -f src/VolunteerService/VolunteerService.Api/Dockerfile \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+            .
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+
+  deploy:
+    name: Deploy to Container Apps
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    environment: production
+
+    steps:
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Deploy to Container App
+        uses: azure/container-apps-deploy-action@v1
+        with:
+          containerAppName: volunteer-service
+          resourceGroup: ${{ secrets.AZURE_RESOURCE_GROUP }}
+          imageToDeploy: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  DOTNET_VERSION: '8.0.x'
+
+jobs:
+  build-and-test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore --configuration Release
+
+      - name: Test
+        run: dotnet test --no-build --configuration Release --verbosity normal --logger "trx;LogFileName=test-results.trx"
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results
+          path: '**/test-results.trx'
+
+  lint:
+    name: Format Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Check formatting
+        run: dotnet format --verify-no-changes --verbosity diagnostic

--- a/src/AdminService/AdminService.Api/Dockerfile
+++ b/src/AdminService/AdminService.Api/Dockerfile
@@ -1,0 +1,29 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+WORKDIR /app
+EXPOSE 8080
+EXPOSE 8081
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+ARG BUILD_CONFIGURATION=Release
+WORKDIR /src
+
+COPY ["src/AdminService/AdminService.Api/AdminService.Api.csproj", "src/AdminService/AdminService.Api/"]
+COPY ["src/AdminService/AdminService.Application/AdminService.Application.csproj", "src/AdminService/AdminService.Application/"]
+COPY ["src/Volentry.Core/Volentry.Core.csproj", "src/Volentry.Core/"]
+COPY ["src/Volentry.Infrastructure/Volentry.Infrastructure.csproj", "src/Volentry.Infrastructure/"]
+
+RUN dotnet restore "src/AdminService/AdminService.Api/AdminService.Api.csproj"
+
+COPY . .
+
+RUN dotnet build "src/AdminService/AdminService.Api/AdminService.Api.csproj" \
+    -c $BUILD_CONFIGURATION -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "src/AdminService/AdminService.Api/AdminService.Api.csproj" \
+    -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "AdminService.Api.dll"]

--- a/src/AdminService/AdminService.Api/Dockerfile
+++ b/src/AdminService/AdminService.Api/Dockerfile
@@ -20,6 +20,7 @@ RUN dotnet build "src/AdminService/AdminService.Api/AdminService.Api.csproj" \
     -c $BUILD_CONFIGURATION -o /app/build
 
 FROM build AS publish
+ARG BUILD_CONFIGURATION=Release
 RUN dotnet publish "src/AdminService/AdminService.Api/AdminService.Api.csproj" \
     -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 

--- a/src/VolunteerService/VolunteerService.Api/Dockerfile
+++ b/src/VolunteerService/VolunteerService.Api/Dockerfile
@@ -20,6 +20,7 @@ RUN dotnet build "src/VolunteerService/VolunteerService.Api/VolunteerService.Api
     -c $BUILD_CONFIGURATION -o /app/build
 
 FROM build AS publish
+ARG BUILD_CONFIGURATION=Release
 RUN dotnet publish "src/VolunteerService/VolunteerService.Api/VolunteerService.Api.csproj" \
     -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 

--- a/src/VolunteerService/VolunteerService.Api/Dockerfile
+++ b/src/VolunteerService/VolunteerService.Api/Dockerfile
@@ -1,0 +1,29 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+WORKDIR /app
+EXPOSE 8080
+EXPOSE 8081
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+ARG BUILD_CONFIGURATION=Release
+WORKDIR /src
+
+COPY ["src/VolunteerService/VolunteerService.Api/VolunteerService.Api.csproj", "src/VolunteerService/VolunteerService.Api/"]
+COPY ["src/VolunteerService/VolunteerService.Application/VolunteerService.Application.csproj", "src/VolunteerService/VolunteerService.Application/"]
+COPY ["src/Volentry.Core/Volentry.Core.csproj", "src/Volentry.Core/"]
+COPY ["src/Volentry.Infrastructure/Volentry.Infrastructure.csproj", "src/Volentry.Infrastructure/"]
+
+RUN dotnet restore "src/VolunteerService/VolunteerService.Api/VolunteerService.Api.csproj"
+
+COPY . .
+
+RUN dotnet build "src/VolunteerService/VolunteerService.Api/VolunteerService.Api.csproj" \
+    -c $BUILD_CONFIGURATION -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "src/VolunteerService/VolunteerService.Api/VolunteerService.Api.csproj" \
+    -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "VolunteerService.Api.dll"]


### PR DESCRIPTION
## What

Adds GitHub Actions workflows and Dockerfiles for both services.

## CI (runs on every PR + main push)
- `ci.yml` — restore, build (Release), test, upload TRX results, format check

## CD (runs on main push, path-filtered per service)
- `cd-volunteer-service.yml` — build Docker image → push to ACR → deploy to Container App
- `cd-admin-service.yml` — same for AdminService

## Dockerfiles
- Multi-stage builds (sdk → publish → aspnet runtime)
- Context is repo root so shared libs are in scope
- `.dockerignore` keeps images lean

## Required GitHub Secrets (to activate CD)
```
AZURE_CONTAINER_REGISTRY   # ACR name (without .azurecr.io)
ACR_USERNAME
ACR_PASSWORD
AZURE_CREDENTIALS          # Service principal JSON
AZURE_RESOURCE_GROUP
```

CI will work immediately. CD workflows will fail until Azure infra + secrets are configured (Terraform epic).