### PR TITLE
feat: Terraform infrastructure for Azure resources

### DIFF
--- a/infrastructure/terraform/.gitignore
+++ b/infrastructure/terraform/.gitignore
@@ -1,5 +1,4 @@
 .terraform/
-.terraform.lock.hcl
 terraform.tfstate
 terraform.tfstate.backup
 *.tfvars

--- a/infrastructure/terraform/.gitignore
+++ b/infrastructure/terraform/.gitignore
@@ -1,0 +1,11 @@
+.terraform/
+.terraform.lock.hcl
+terraform.tfstate
+terraform.tfstate.backup
+*.tfvars
+!terraform.tfvars.example
+crash.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json

--- a/infrastructure/terraform/acr.tf
+++ b/infrastructure/terraform/acr.tf
@@ -1,0 +1,8 @@
+resource "azurerm_container_registry" "main" {
+  name                = local.acr_name
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  sku                 = "Basic"
+  admin_enabled       = var.acr_admin_enabled
+  tags                = local.common_tags
+}

--- a/infrastructure/terraform/bootstrap-state.sh
+++ b/infrastructure/terraform/bootstrap-state.sh
@@ -5,14 +5,24 @@
 #
 # Usage:
 #   chmod +x bootstrap-state.sh
-#   ./bootstrap-state.sh
+#   ./bootstrap-state.sh [suffix]
+#
+# The optional suffix (e.g. your initials or a short random string) ensures the
+# storage account name is globally unique. If omitted, a random 4-char suffix is generated.
+#
+# Example:
+#   ./bootstrap-state.sh ab42
 
 set -euo pipefail
 
 LOCATION="australiaeast"
 RG="rg-volentry-tfstate"
-STORAGE_ACCOUNT="stvolentrystate"
 CONTAINER="tfstate"
+
+SUFFIX="${1:-$(cat /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 4)}"
+STORAGE_ACCOUNT="stvolentry${SUFFIX}"
+
+echo "Using storage account: $STORAGE_ACCOUNT"
 
 echo "Creating resource group: $RG"
 az group create --name "$RG" --location "$LOCATION"
@@ -24,7 +34,15 @@ az storage account create \
   --location "$LOCATION" \
   --sku Standard_LRS \
   --kind StorageV2 \
-  --allow-blob-public-access false
+  --allow-blob-public-access false \
+  --min-tls-version TLS1_2
+
+echo "Enabling blob versioning and soft delete"
+az storage account blob-service-properties update \
+  --account-name "$STORAGE_ACCOUNT" \
+  --resource-group "$RG" \
+  --enable-versioning true \
+  --delete-retention-days 30
 
 echo "Creating blob container: $CONTAINER"
 az storage container create \
@@ -32,6 +50,8 @@ az storage container create \
   --account-name "$STORAGE_ACCOUNT"
 
 echo ""
-echo "Done. Now run:"
-echo "  cd infrastructure/terraform"
-echo "  terraform init"
+echo "Done. Update versions.tf backend with:"
+echo "  storage_account_name = \"$STORAGE_ACCOUNT\""
+echo ""
+echo "Then initialise per environment, e.g.:"
+echo "  terraform init -backend-config=\"key=volentry-dev.tfstate\""

--- a/infrastructure/terraform/bootstrap-state.sh
+++ b/infrastructure/terraform/bootstrap-state.sh
@@ -1,0 +1,37 @@
+# Terraform state backend bootstrap
+#
+# Run this ONCE before `terraform init` to create the remote state storage.
+# Requires Azure CLI logged in: `az login`
+#
+# Usage:
+#   chmod +x bootstrap-state.sh
+#   ./bootstrap-state.sh
+
+set -euo pipefail
+
+LOCATION="australiaeast"
+RG="rg-volentry-tfstate"
+STORAGE_ACCOUNT="stvolentrystate"
+CONTAINER="tfstate"
+
+echo "Creating resource group: $RG"
+az group create --name "$RG" --location "$LOCATION"
+
+echo "Creating storage account: $STORAGE_ACCOUNT"
+az storage account create \
+  --name "$STORAGE_ACCOUNT" \
+  --resource-group "$RG" \
+  --location "$LOCATION" \
+  --sku Standard_LRS \
+  --kind StorageV2 \
+  --allow-blob-public-access false
+
+echo "Creating blob container: $CONTAINER"
+az storage container create \
+  --name "$CONTAINER" \
+  --account-name "$STORAGE_ACCOUNT"
+
+echo ""
+echo "Done. Now run:"
+echo "  cd infrastructure/terraform"
+echo "  terraform init"

--- a/infrastructure/terraform/container-apps.tf
+++ b/infrastructure/terraform/container-apps.tf
@@ -51,7 +51,7 @@ resource "azurerm_container_app" "volunteer_service" {
 
       env {
         name  = "ASPNETCORE_ENVIRONMENT"
-        value = var.environment == "prod" ? "Production" : "Staging"
+        value = var.environment == "prod" ? "Production" : var.environment == "dev" ? "Development" : "Staging"
       }
 
       env {
@@ -132,7 +132,7 @@ resource "azurerm_container_app" "admin_service" {
 
       env {
         name  = "ASPNETCORE_ENVIRONMENT"
-        value = var.environment == "prod" ? "Production" : "Staging"
+        value = var.environment == "prod" ? "Production" : var.environment == "dev" ? "Development" : "Staging"
       }
 
       env {

--- a/infrastructure/terraform/container-apps.tf
+++ b/infrastructure/terraform/container-apps.tf
@@ -1,0 +1,169 @@
+resource "azurerm_container_app_environment" "main" {
+  name                       = "cae-${local.prefix}"
+  resource_group_name        = azurerm_resource_group.main.name
+  location                   = azurerm_resource_group.main.location
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+  tags                       = local.common_tags
+}
+
+resource "azurerm_container_app" "volunteer_service" {
+  name                         = "ca-volunteer-svc-${var.environment}"
+  container_app_environment_id = azurerm_container_app_environment.main.id
+  resource_group_name          = azurerm_resource_group.main.name
+  revision_mode                = "Single"
+  tags                         = local.common_tags
+
+  registry {
+    server               = azurerm_container_registry.main.login_server
+    username             = azurerm_container_registry.main.admin_username
+    password_secret_name = "acr-password"
+  }
+
+  secret {
+    name  = "acr-password"
+    value = azurerm_container_registry.main.admin_password
+  }
+
+  secret {
+    name  = "appinsights-connection-string"
+    value = azurerm_application_insights.main.connection_string
+  }
+
+  secret {
+    name  = "cosmosdb-connection-string"
+    value = azurerm_cosmosdb_account.main.primary_sql_connection_string
+  }
+
+  secret {
+    name  = "servicebus-connection-string"
+    value = azurerm_servicebus_namespace.main.default_primary_connection_string
+  }
+
+  template {
+    min_replicas = 0
+    max_replicas = 3
+
+    container {
+      name   = "volunteer-service"
+      image  = var.volunteer_service_image
+      cpu    = 0.25
+      memory = "0.5Gi"
+
+      env {
+        name  = "ASPNETCORE_ENVIRONMENT"
+        value = var.environment == "prod" ? "Production" : "Staging"
+      }
+
+      env {
+        name        = "ApplicationInsights__ConnectionString"
+        secret_name = "appinsights-connection-string"
+      }
+
+      env {
+        name        = "CosmosDb__ConnectionString"
+        secret_name = "cosmosdb-connection-string"
+      }
+
+      env {
+        name        = "ServiceBus__ConnectionString"
+        secret_name = "servicebus-connection-string"
+      }
+
+      env {
+        name  = "CosmosDb__DatabaseName"
+        value = azurerm_cosmosdb_sql_database.volentry.name
+      }
+    }
+  }
+
+  ingress {
+    external_enabled = true
+    target_port      = 8080
+
+    traffic_weight {
+      percentage      = 100
+      latest_revision = true
+    }
+  }
+}
+
+resource "azurerm_container_app" "admin_service" {
+  name                         = "ca-admin-svc-${var.environment}"
+  container_app_environment_id = azurerm_container_app_environment.main.id
+  resource_group_name          = azurerm_resource_group.main.name
+  revision_mode                = "Single"
+  tags                         = local.common_tags
+
+  registry {
+    server               = azurerm_container_registry.main.login_server
+    username             = azurerm_container_registry.main.admin_username
+    password_secret_name = "acr-password"
+  }
+
+  secret {
+    name  = "acr-password"
+    value = azurerm_container_registry.main.admin_password
+  }
+
+  secret {
+    name  = "appinsights-connection-string"
+    value = azurerm_application_insights.main.connection_string
+  }
+
+  secret {
+    name  = "cosmosdb-connection-string"
+    value = azurerm_cosmosdb_account.main.primary_sql_connection_string
+  }
+
+  secret {
+    name  = "servicebus-connection-string"
+    value = azurerm_servicebus_namespace.main.default_primary_connection_string
+  }
+
+  template {
+    min_replicas = 0
+    max_replicas = 2
+
+    container {
+      name   = "admin-service"
+      image  = var.admin_service_image
+      cpu    = 0.25
+      memory = "0.5Gi"
+
+      env {
+        name  = "ASPNETCORE_ENVIRONMENT"
+        value = var.environment == "prod" ? "Production" : "Staging"
+      }
+
+      env {
+        name        = "ApplicationInsights__ConnectionString"
+        secret_name = "appinsights-connection-string"
+      }
+
+      env {
+        name        = "CosmosDb__ConnectionString"
+        secret_name = "cosmosdb-connection-string"
+      }
+
+      env {
+        name        = "ServiceBus__ConnectionString"
+        secret_name = "servicebus-connection-string"
+      }
+
+      env {
+        name  = "CosmosDb__DatabaseName"
+        value = azurerm_cosmosdb_sql_database.volentry.name
+      }
+    }
+  }
+
+  ingress {
+    external_enabled = true
+    target_port      = 8080
+
+    traffic_weight {
+      percentage      = 100
+      latest_revision = true
+    }
+  }
+}

--- a/infrastructure/terraform/cosmosdb.tf
+++ b/infrastructure/terraform/cosmosdb.tf
@@ -1,0 +1,64 @@
+resource "azurerm_cosmosdb_account" "main" {
+  name                = "cosmos-${local.prefix}"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  offer_type          = "Standard"
+  kind                = "GlobalDocumentDB"
+  free_tier_enabled   = var.cosmosdb_free_tier
+
+  consistency_policy {
+    consistency_level = "Session"
+  }
+
+  geo_location {
+    location          = azurerm_resource_group.main.location
+    failover_priority = 0
+  }
+
+  tags = local.common_tags
+}
+
+resource "azurerm_cosmosdb_sql_database" "volentry" {
+  name                = "volentry"
+  resource_group_name = azurerm_resource_group.main.name
+  account_name        = azurerm_cosmosdb_account.main.name
+}
+
+# Event store — partition key is /orgSlug for multi-tenant isolation
+resource "azurerm_cosmosdb_sql_container" "events" {
+  name                = "events"
+  resource_group_name = azurerm_resource_group.main.name
+  account_name        = azurerm_cosmosdb_account.main.name
+  database_name       = azurerm_cosmosdb_sql_database.volentry.name
+  partition_key_paths = ["/orgSlug"]
+
+  indexing_policy {
+    indexing_mode = "consistent"
+
+    included_path {
+      path = "/*"
+    }
+
+    excluded_path {
+      path = "/payload/?"
+    }
+  }
+}
+
+# Materialised view: volunteer events read model
+resource "azurerm_cosmosdb_sql_container" "volunteer_events" {
+  name                = "volunteer-events"
+  resource_group_name = azurerm_resource_group.main.name
+  account_name        = azurerm_cosmosdb_account.main.name
+  database_name       = azurerm_cosmosdb_sql_database.volentry.name
+  partition_key_paths = ["/orgSlug"]
+}
+
+# Materialised view: signups read model
+resource "azurerm_cosmosdb_sql_container" "signups" {
+  name                = "signups"
+  resource_group_name = azurerm_resource_group.main.name
+  account_name        = azurerm_cosmosdb_account.main.name
+  database_name       = azurerm_cosmosdb_sql_database.volentry.name
+  partition_key_paths = ["/orgSlug"]
+}

--- a/infrastructure/terraform/cosmosdb.tf
+++ b/infrastructure/terraform/cosmosdb.tf
@@ -22,6 +22,11 @@ resource "azurerm_cosmosdb_sql_database" "volentry" {
   name                = "volentry"
   resource_group_name = azurerm_resource_group.main.name
   account_name        = azurerm_cosmosdb_account.main.name
+
+  # Shared autoscale throughput — containers inherit this unless they set their own
+  autoscale_settings {
+    max_throughput = 1000
+  }
 }
 
 # Event store — partition key is /orgSlug for multi-tenant isolation

--- a/infrastructure/terraform/keyvault.tf
+++ b/infrastructure/terraform/keyvault.tf
@@ -1,0 +1,52 @@
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_key_vault" "main" {
+  name                = "kv-${local.prefix}"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  sku_name            = "standard"
+
+  soft_delete_retention_days = 7
+  purge_protection_enabled   = false
+
+  tags = local.common_tags
+}
+
+# Allow the deploying principal (CI/CD service principal) full access
+resource "azurerm_key_vault_access_policy" "deployer" {
+  key_vault_id = azurerm_key_vault.main.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = data.azurerm_client_config.current.object_id
+
+  secret_permissions = [
+    "Get", "List", "Set", "Delete", "Purge", "Recover"
+  ]
+}
+
+# Store CosmosDB connection string in Key Vault
+resource "azurerm_key_vault_secret" "cosmosdb_connection_string" {
+  name         = "CosmosDb--ConnectionString"
+  value        = azurerm_cosmosdb_account.main.primary_sql_connection_string
+  key_vault_id = azurerm_key_vault.main.id
+
+  depends_on = [azurerm_key_vault_access_policy.deployer]
+}
+
+# Store Service Bus connection string in Key Vault
+resource "azurerm_key_vault_secret" "servicebus_connection_string" {
+  name         = "ServiceBus--ConnectionString"
+  value        = azurerm_servicebus_namespace.main.default_primary_connection_string
+  key_vault_id = azurerm_key_vault.main.id
+
+  depends_on = [azurerm_key_vault_access_policy.deployer]
+}
+
+# Store App Insights connection string in Key Vault
+resource "azurerm_key_vault_secret" "appinsights_connection_string" {
+  name         = "ApplicationInsights--ConnectionString"
+  value        = azurerm_application_insights.main.connection_string
+  key_vault_id = azurerm_key_vault.main.id
+
+  depends_on = [azurerm_key_vault_access_policy.deployer]
+}

--- a/infrastructure/terraform/keyvault.tf
+++ b/infrastructure/terraform/keyvault.tf
@@ -20,7 +20,7 @@ resource "azurerm_key_vault_access_policy" "deployer" {
   object_id    = data.azurerm_client_config.current.object_id
 
   secret_permissions = [
-    "Get", "List", "Set", "Delete", "Purge", "Recover"
+    "Get", "List", "Set", "Delete", "Recover"
   ]
 }
 

--- a/infrastructure/terraform/locals.tf
+++ b/infrastructure/terraform/locals.tf
@@ -1,0 +1,11 @@
+locals {
+  prefix = "volentry-${var.environment}"
+  # ACR names cannot contain hyphens
+  acr_name = "acrvolentry${var.environment}"
+
+  common_tags = merge(var.tags, {
+    environment = var.environment
+    project     = "volentry"
+    managed_by  = "terraform"
+  })
+}

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -1,0 +1,5 @@
+resource "azurerm_resource_group" "main" {
+  name     = "rg-${local.prefix}"
+  location = var.location
+  tags     = local.common_tags
+}

--- a/infrastructure/terraform/monitoring.tf
+++ b/infrastructure/terraform/monitoring.tf
@@ -1,0 +1,17 @@
+resource "azurerm_log_analytics_workspace" "main" {
+  name                = "law-${local.prefix}"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+  tags                = local.common_tags
+}
+
+resource "azurerm_application_insights" "main" {
+  name                = "appi-${local.prefix}"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  workspace_id        = azurerm_log_analytics_workspace.main.id
+  application_type    = "web"
+  tags                = local.common_tags
+}

--- a/infrastructure/terraform/outputs.tf
+++ b/infrastructure/terraform/outputs.tf
@@ -1,0 +1,59 @@
+# Resource group
+output "resource_group_name" {
+  description = "Name of the resource group — use as AZURE_RESOURCE_GROUP secret"
+  value       = azurerm_resource_group.main.name
+}
+
+# ACR — needed for GitHub Actions CD secrets
+output "acr_login_server" {
+  description = "ACR login server — use as AZURE_CONTAINER_REGISTRY secret"
+  value       = azurerm_container_registry.main.login_server
+}
+
+output "acr_admin_username" {
+  description = "ACR admin username — use as ACR_USERNAME secret"
+  value       = azurerm_container_registry.main.admin_username
+  sensitive   = true
+}
+
+output "acr_admin_password" {
+  description = "ACR admin password — use as ACR_PASSWORD secret"
+  value       = azurerm_container_registry.main.admin_password
+  sensitive   = true
+}
+
+# Container App URLs
+output "volunteer_service_url" {
+  description = "Public URL for the Volunteer Service"
+  value       = "https://${azurerm_container_app.volunteer_service.ingress[0].fqdn}"
+}
+
+output "admin_service_url" {
+  description = "Public URL for the Admin Service"
+  value       = "https://${azurerm_container_app.admin_service.ingress[0].fqdn}"
+}
+
+# CosmosDB
+output "cosmosdb_endpoint" {
+  description = "CosmosDB account endpoint"
+  value       = azurerm_cosmosdb_account.main.endpoint
+}
+
+# Key Vault
+output "key_vault_uri" {
+  description = "Key Vault URI — used by app config for secret references"
+  value       = azurerm_key_vault.main.vault_uri
+}
+
+# Application Insights
+output "appinsights_instrumentation_key" {
+  description = "App Insights instrumentation key"
+  value       = azurerm_application_insights.main.instrumentation_key
+  sensitive   = true
+}
+
+output "appinsights_connection_string" {
+  description = "App Insights connection string"
+  value       = azurerm_application_insights.main.connection_string
+  sensitive   = true
+}

--- a/infrastructure/terraform/servicebus.tf
+++ b/infrastructure/terraform/servicebus.tf
@@ -1,0 +1,23 @@
+resource "azurerm_servicebus_namespace" "main" {
+  name                = "sb-${local.prefix}"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  sku                 = "Standard"
+  tags                = local.common_tags
+}
+
+resource "azurerm_servicebus_queue" "signup_events" {
+  name         = "signup-events"
+  namespace_id = azurerm_servicebus_namespace.main.id
+
+  max_delivery_count = 10
+  lock_duration      = "PT1M"
+}
+
+resource "azurerm_servicebus_queue" "cancellation_events" {
+  name         = "cancellation-events"
+  namespace_id = azurerm_servicebus_namespace.main.id
+
+  max_delivery_count = 10
+  lock_duration      = "PT1M"
+}

--- a/infrastructure/terraform/terraform.tfvars.example
+++ b/infrastructure/terraform/terraform.tfvars.example
@@ -1,0 +1,9 @@
+# Copy this file to terraform.tfvars and fill in values
+
+environment        = "dev"
+location           = "australiaeast"
+cosmosdb_free_tier = false  # set true if no free tier used in this subscription yet
+
+tags = {
+  owner = "your-name"
+}

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -1,0 +1,44 @@
+variable "environment" {
+  description = "Deployment environment (dev, staging, prod)"
+  type        = string
+  validation {
+    condition     = contains(["dev", "staging", "prod"], var.environment)
+    error_message = "Environment must be one of: dev, staging, prod."
+  }
+}
+
+variable "location" {
+  description = "Azure region"
+  type        = string
+  default     = "australiaeast"
+}
+
+variable "tags" {
+  description = "Tags applied to all resources"
+  type        = map(string)
+  default     = {}
+}
+
+variable "cosmosdb_free_tier" {
+  description = "Enable CosmosDB free tier (only one per subscription)"
+  type        = bool
+  default     = false
+}
+
+variable "volunteer_service_image" {
+  description = "Volunteer Service container image (e.g. acr.azurecr.io/volunteer-service:latest)"
+  type        = string
+  default     = "mcr.microsoft.com/azuredocs/containerapps-helloworld:latest"
+}
+
+variable "admin_service_image" {
+  description = "Admin Service container image (e.g. acr.azurecr.io/admin-service:latest)"
+  type        = string
+  default     = "mcr.microsoft.com/azuredocs/containerapps-helloworld:latest"
+}
+
+variable "acr_admin_enabled" {
+  description = "Enable ACR admin user (needed for GitHub Actions CD)"
+  type        = bool
+  default     = true
+}

--- a/infrastructure/terraform/versions.tf
+++ b/infrastructure/terraform/versions.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_version = ">= 1.7.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.110"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+
+  backend "azurerm" {
+    resource_group_name  = "rg-volentry-tfstate"
+    storage_account_name = "stvolentrystate"
+    container_name       = "tfstate"
+    key                  = "volentry.terraform.tfstate"
+  }
+}
+
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy    = true
+      recover_soft_deleted_key_vaults = true
+    }
+  }
+}

--- a/infrastructure/terraform/versions.tf
+++ b/infrastructure/terraform/versions.tf
@@ -6,24 +6,23 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.110"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = "~> 3.6"
-    }
   }
 
   backend "azurerm" {
     resource_group_name  = "rg-volentry-tfstate"
     storage_account_name = "stvolentrystate"
     container_name       = "tfstate"
-    key                  = "volentry.terraform.tfstate"
+    # key is intentionally omitted — provide per environment at init time:
+    #   terraform init -backend-config="key=volentry-dev.tfstate"
+    #   terraform init -backend-config="key=volentry-staging.tfstate"
+    #   terraform init -backend-config="key=volentry-prod.tfstate"
   }
 }
 
 provider "azurerm" {
   features {
     key_vault {
-      purge_soft_delete_on_destroy    = true
+      purge_soft_delete_on_destroy    = false
       recover_soft_deleted_key_vaults = true
     }
   }


### PR DESCRIPTION
## Summary
Provisions all Azure infrastructure needed to run Volentry in a target environment.

## Resources
- **Resource Group** — `rg-volentry-{env}`
- **CosmosDB** — account + `volentry` database + 3 containers (`events`, `volunteer-events`, `signups`), shared autoscale throughput
- **Azure Container Registry** — Basic SKU, admin enabled (for GitHub Actions CD)
- **Container Apps** — shared environment + `ca-volunteer-svc` + `ca-admin-svc` (min 0 replicas)
- **Key Vault** — stores CosmosDB, Service Bus, App Insights connection strings
- **Service Bus** — Standard namespace + `signup-events` + `cancellation-events` queues
- **Monitoring** — Log Analytics workspace + Application Insights

## How to deploy
```bash
# 1. Bootstrap remote state (once only)
cd infrastructure/terraform
./bootstrap-state.sh <suffix>   # e.g. ./bootstrap-state.sh ab42

# 2. Deploy
cp terraform.tfvars.example terraform.tfvars  # edit environment/location
terraform init -backend-config="key=volentry-dev.tfstate"
terraform plan
terraform apply
```

## Outputs
After apply, run `terraform output` to get values for GitHub secrets:
- `acr_login_server` → `AZURE_CONTAINER_REGISTRY`
- `acr_admin_username` → `ACR_USERNAME`
- `acr_admin_password` → `ACR_PASSWORD`
- `resource_group_name` → `AZURE_RESOURCE_GROUP`